### PR TITLE
Use floats instead of ints for internally storing biases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 import os
 from io import open
 from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 
 
 # Load package info, without importing the package
@@ -26,6 +27,22 @@ try:
         exec(f.read(), package_info)
 except SyntaxError:
     execfile(package_info_path, package_info)
+
+extra_compile_args = {
+    'msvc': ['/std:c++14'],
+    'unix': ['-std=c++11'],
+}
+
+
+class build_ext_compiler_check(build_ext):
+    def build_extensions(self):
+        compiler = self.compiler.compiler_type
+
+        compile_args = extra_compile_args[compiler]
+        for ext in self.extensions:
+            ext.extra_compile_args = compile_args
+
+        build_ext.build_extensions(self)
 
 
 packages = ['tabu']
@@ -64,6 +81,7 @@ setup(
     url=package_info['__url__'],
     license=package_info['__license__'],
     ext_modules=ext_modules,
+    cmdclass={'build_ext': build_ext_compiler_check},
     py_modules=py_modules,
     packages=packages,
     install_requires=install_requires,

--- a/tabu/sampler.py
+++ b/tabu/sampler.py
@@ -44,13 +44,12 @@ class TabuSampler(dimod.Sampler):
 
     def __init__(self):
         self.parameters = {'tenure': [],
-                           'scale_factor': [],
                            'timeout': [],
                            'num_reads': [],
                            'init_solution': []}
         self.properties = {}
 
-    def sample(self, bqm, init_solution=None, tenure=None, scale_factor=1, timeout=20, num_reads=1):
+    def sample(self, bqm, init_solution=None, tenure=None, timeout=20, num_reads=1):
         """Run a tabu search on a given binary quadratic model.
 
         Args:
@@ -64,10 +63,6 @@ class TabuSampler(dimod.Sampler):
                 explored solutions kept in memory.
                 Default is a quarter of the number of problem variables up to
                 a maximum value of 20.
-            scale_factor (number, optional):
-                Scaling factor for linear and quadratic biases in the BQM. Internally, the BQM is
-                converted to a QUBO matrix, and elements are stored as long ints
-                using ``internal_q = long int (q * scale_factor)``.
             timeout (int, optional):
                 Total running time in milliseconds.
             num_reads (int, optional): Number of reads. Each run of the tabu algorithm
@@ -127,7 +122,7 @@ class TabuSampler(dimod.Sampler):
         for _ in range(num_reads):
             if init_sample is None:
                 init_sample = self._bqm_sample_to_tabu_sample(self._random_sample(bqm.binary), bqm.binary)
-            r = TabuSearch(qubo, init_sample, tenure, scale_factor, timeout)
+            r = TabuSearch(qubo, init_sample, tenure, timeout)
             sample = self._tabu_sample_to_bqm_sample(list(r.bestSolution()), bqm.binary)
             energy = bqm.binary.energy(sample)
             samples.append(sample)

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -20,7 +20,7 @@ using std::vector;
 
 double bqpSolver_tabooSearch(
     BQP *bqp,
-    int *starting,
+    vector<int> &starting,
     double startingObjective,
     int tt,
     long long ZCoeff,
@@ -36,19 +36,16 @@ double bqpSolver_tabooSearch(
     int bestK;
     double localMinCost, cost = 0;
     double prevCost;
-    vector<int> u_tabu(bqp->nVars);
-    int *taboo = vector_data<int>(u_tabu);
-    vector<int> u_sol(bqp->nVars);
-    int *solution = vector_data<int>(u_sol);
+    vector<int> taboo(bqp->nVars);
+    vector<int> solution(bqp->nVars);
     int tabooTenure = (20 < (int)(bqp->nVars / 4.0))? 20 : (int)(bqp->nVars / 4.0);
     long long maxIter = (500000 > ZCoeff * (long long)bqp->nVars)? 500000 : ZCoeff * (long long)bqp->nVars;
-    vector<double> u_change(bqp->nVars);
-    double *changeInObjective = vector_data<double>(u_change);
+     vector<double> changeInObjective(bqp->nVars);
     double change;
     double timeLimit = (((double)timeLimitInMilliSecs * (double)CLOCKS_PER_SEC) / (1000.0));
 
-    vector<int> u_tieList(bqp->nVars);
-    int numTies = 0, *tieList = vector_data<int>(u_tieList);
+    vector<int> tieList(bqp->nVars);
+    int numTies = 0;
 
     if (tt > 0) {
       tabooTenure = tt;
@@ -138,7 +135,7 @@ double bqpSolver_tabooSearch(
     return bqp->solutionQuality;
 }
 
-double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObjective, double *changeInObjective) {
+double bqpSolver_localSearchInternal(BQP *bqp, vector<int> &starting, double startingObjective, vector<double> &changeInObjective) {
     int i, j;
     long long iter = 0;
     double objective, change;
@@ -169,10 +166,9 @@ double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObj
     return bqp->solutionQuality;
 }
 
-double bqpSolver_localSearch(BQP *bqp, int *starting) {
+double bqpSolver_localSearch(BQP *bqp, vector<int> &starting) {
     int i;
-    vector<double> u_change(bqp->nVars);
-    double *changeInObjective = vector_data<double>(u_change);
+    vector<double> changeInObjective(bqp->nVars);
     for(i = 0; i < bqp->nVars; i++) {
         changeInObjective[i] = bqpUtil_getChangeInObjective(bqp, starting, i);
     }
@@ -180,17 +176,13 @@ double bqpSolver_localSearch(BQP *bqp, int *starting) {
     return bqp->solutionQuality;
 }
 
-void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<double> > &C, int *I) {
+void bqpSolver_selectVariables(BQP *bqp, int n, vector< vector<double> > &C, vector<int> &I) {
     int i, ctr;
-    vector<double> u_d(bqp->nVars);
-    double *d = vector_data<double>(u_d);
-    vector<int> u_sel(bqp->nVars);
-    int *selected = vector_data<int>(u_sel);
+    vector<double> d(bqp->nVars);
+    vector<int> selected(bqp->nVars);
     int selectedVar = 0;
-    vector<double> u_e(bqp->nVars);
-    double *e = vector_data<double>(u_e);
-    vector<double> u_prob(bqp->nVars);
-    double *prob = vector_data<double>(u_prob);
+    vector<double> e(bqp->nVars);
+    vector<double> prob(bqp->nVars);
     double selectedProb, prevProb, sumE;
     int allDsEqual;
     double dmin, dmax;
@@ -282,19 +274,14 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<double> > &C, int 
     }
 }
 
-void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<double> > &C, int *I, int n) {
+void bqpSolver_steepestAscent(vector<int> &solution, BQP *bqp, vector< vector<double> > &C, vector<int> &I, int n) {
     int i, j, ctr;
     int idI, idJ, r, v = 0;
-    vector<double> u_h1(bqp->nVars);
-    vector<double> u_h2(bqp->nVars);
-    vector<double> u_q1(bqp->nVars);
-    vector<double> u_q2(bqp->nVars);
-    double *h1 = vector_data<double>(u_h1);
-    double *h2 = vector_data<double>(u_h2);
-    double *q1 = vector_data<double>(u_q1);
-    double *q2 = vector_data<double>(u_q2);
-    vector<int> u_visited(bqp->nVars);
-    int *visited = vector_data<int>(u_visited);
+    vector<double> h1(bqp->nVars);
+    vector<double> h2(bqp->nVars);
+    vector<double> q1(bqp->nVars);
+    vector<double> q2(bqp->nVars);
+    vector<int> visited(bqp->nVars);
     double V1, V2;
     for(i = 0; i < bqp->nVars; i++) {
         visited[i] = 0;
@@ -352,7 +339,7 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<double> > &
     }
 }
 
-void bqpSolver_computeC(vector<vector<double> > &C, BQP *bqp, int *solution) {
+void bqpSolver_computeC(vector< vector<double> > &C, BQP *bqp, vector<int> &solution) {
     int i, j;
     for(i = 0; i < bqp->nVars; i++) {
         C[i][i] = -bqp->Q[i][i];
@@ -372,20 +359,17 @@ double bqpSolver_multiStartTabooSearch(
     long long timeLimitInMilliSecs,
     int numStarts,
     int tabuTenure,
-    const int *initSolution,
+    vector<int> const &initSolution,
     const bqpSolver_Callback *callback
 ) {
 
     clock_t startTime = clock();
     int i;
     long iter;
-    vector<vector<double> > C(bqp->nVars);
-    vector<int> u_I(bqp->nVars);
-    int *I = vector_data<int>(u_I);
-    vector<int> u_sol(bqp->nVars);
-    int *solution = vector_data<int>(u_sol);
-    vector<int> u_bestSol(bqp->nVars);
-    int *bestSolution = vector_data<int>(u_bestSol);
+    vector< vector<double> > C(bqp->nVars);
+    vector<int> I(bqp->nVars);
+    vector<int> solution(bqp->nVars);
+    vector<int> bestSolution(bqp->nVars);
     double bestSolutionQuality;
     int n;
     int Z1Coeff = (bqp->nVars <= 500)? 10000 : 25000;
@@ -397,7 +381,7 @@ double bqpSolver_multiStartTabooSearch(
     bqpUtil_convertBQPToUpperTriangular(bqp);
     bqpUtil_initBQPSolution(bqp, initSolution);
 
-    bqpSolver_tabooSearch(bqp, vector_data<int>(bqp->solution), bqp->solutionQuality, tabuTenure, Z1Coeff, timeLimitInMilliSecs, callback);
+    bqpSolver_tabooSearch(bqp, bqp->solution, bqp->solutionQuality, tabuTenure, Z1Coeff, timeLimitInMilliSecs, callback);
     bestSolutionQuality = bqp->solutionQuality;
     for(i = 0; i < bqp->nVars; i++) {
         bestSolution[i] = bqp->solution[i];
@@ -409,7 +393,7 @@ double bqpSolver_multiStartTabooSearch(
         if(n > bqp->nVars) {
             n = bqp->nVars;
         }
-        bqpSolver_computeC(C, bqp, vector_data<int>(bqp->solution));
+        bqpSolver_computeC(C, bqp, bqp->solution);
         bqpSolver_selectVariables(bqp, n, C, I);
         bqpSolver_steepestAscent(solution, bqp, C, I, n);
         for(i = 0; i < n; i++) {
@@ -417,8 +401,8 @@ double bqpSolver_multiStartTabooSearch(
                 bqp->solution[I[i]] = 1 - bqp->solution[I[i]];
             }
         }
-        bqp->solutionQuality = bqpUtil_getObjective(bqp, vector_data<int>(bqp->solution));
-        bqpSolver_tabooSearch(bqp, vector_data<int>(bqp->solution), bqp->solutionQuality, tabuTenure, Z2Coeff, timeLimitInMilliSecs - (((clock() - startTime) * 1000.0) / (double)CLOCKS_PER_SEC), callback);
+        bqp->solutionQuality = bqpUtil_getObjective(bqp, bqp->solution);
+        bqpSolver_tabooSearch(bqp, bqp->solution, bqp->solutionQuality, tabuTenure, Z2Coeff, timeLimitInMilliSecs - (((clock() - startTime) * 1000.0) / (double)CLOCKS_PER_SEC), callback);
         if(bestSolutionQuality > bqp->solutionQuality) {
             bestSolutionQuality = bqp->solutionQuality;
             for(i = 0; i < bqp->nVars; i++) {
@@ -441,10 +425,8 @@ double bqpSolver_naiveSearch(BQP *bqp) {
     unsigned long long num, grayNum;
     double cost, prevCost, minCost;
     int flippedBit;
-    vector<int> u_sol(bqp->nVars);
-    int *solution = vector_data<int>(u_sol);
-    vector<int> u_preSol(bqp->nVars);
-    int *prevSolution = vector_data<int>(u_preSol);
+    vector<int> solution(bqp->nVars);
+    vector<int> prevSolution(bqp->nVars);
     if(bqp->nVars > 64) {
         bqpUtil_randomizeBQPSolution(bqp);
         return bqp->solutionQuality;
@@ -487,7 +469,7 @@ double bqpSolver_naiveSearch(BQP *bqp) {
     return bqp->solutionQuality;
 }
 
-double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, double startingObjective, double *changeInObjective) {
+double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, vector<int> &starting, vector<int> &restricted, double startingObjective, vector<double> &changeInObjective) {
     int i, j;
     long long iter = 0;
     double objective, change;
@@ -521,10 +503,9 @@ double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *res
     return bqp->solutionQuality;
 }
 
-double bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted) {
+double bqpSolver_restrictedLocalSearch(BQP *bqp, vector<int> &starting, vector<int> &restricted) {
     int i;
-    vector<double> u_change(bqp->nVars);
-    double *changeInObjective = vector_data<double>(u_change);
+    vector<double> changeInObjective(bqp->nVars);
     for(i = 0; i < bqp->nVars; i++) {
         changeInObjective[i] = bqpUtil_getChangeInObjective(bqp, starting, i);
     }

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -191,7 +191,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector< vector<double> > &C, vec
     }
     for(ctr = 0; ctr < n; ctr++) {
         dmin = std::numeric_limits<double>::max();
-        dmax = std::numeric_limits<double>::lowest();
+        dmax = -std::numeric_limits<double>::max();
         for(i = 0; i < bqp->nVars; i++) {
             if(selected[i] == 1) {
                 continue;
@@ -298,8 +298,8 @@ void bqpSolver_steepestAscent(vector<int> &solution, BQP *bqp, vector< vector<do
         h2[idI] = h2[idI] * 1;
     }
     for(ctr = 0; ctr < n; ctr++) {
-        V1 = std::numeric_limits<double>::lowest();
-        V2 = std::numeric_limits<double>::lowest();
+        V1 = -std::numeric_limits<double>::max();
+        V2 = -std::numeric_limits<double>::max();
         for(i = 0; i < n; i++) {
             idI = I[i];
             if(visited[idI] == 1) {

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -29,7 +29,7 @@ double bqpSolver_tabooSearch(
 ) {
     bqp->restartNum++;/*added to record more statistics.*/
     clock_t startTime = clock();
-    int i, k, j;
+    int i, k;
     int globalMinFound;
     long /*objectiveChangeCtr = 0,*/ localSearchCtr = 0;
     long long iter = 0;
@@ -138,7 +138,7 @@ double bqpSolver_tabooSearch(
 double bqpSolver_localSearchInternal(BQP *bqp, vector<int> &starting, double startingObjective, vector<double> &changeInObjective) {
     int i, j;
     long long iter = 0;
-    double objective, change;
+    double change;
     int improved;
     for(i = 0; i < bqp->nVars; i++) {
         bqp->solution[i] = starting[i];
@@ -184,7 +184,6 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector< vector<double> > &C, vec
     vector<double> e(bqp->nVars);
     vector<double> prob(bqp->nVars);
     double selectedProb, prevProb, sumE;
-    int allDsEqual;
     double dmin, dmax;
     for(i = 0; i < bqp->nVars; i++) {
         selected[i] = 0;
@@ -193,7 +192,6 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector< vector<double> > &C, vec
     for(ctr = 0; ctr < n; ctr++) {
         dmin = std::numeric_limits<double>::max();
         dmax = std::numeric_limits<double>::lowest();
-        allDsEqual = 1;
         for(i = 0; i < bqp->nVars; i++) {
             if(selected[i] == 1) {
                 continue;

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -200,7 +200,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<double> > &C, int 
     }
     for(ctr = 0; ctr < n; ctr++) {
         dmin = std::numeric_limits<double>::max();
-        dmax = std::numeric_limits<double>::min();
+        dmax = std::numeric_limits<double>::lowest();
         allDsEqual = 1;
         for(i = 0; i < bqp->nVars; i++) {
             if(selected[i] == 1) {
@@ -313,8 +313,8 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<double> > &
         h2[idI] = h2[idI] * 1;
     }
     for(ctr = 0; ctr < n; ctr++) {
-        V1 = std::numeric_limits<double>::min();
-        V2 = std::numeric_limits<double>::min();
+        V1 = std::numeric_limits<double>::lowest();
+        V2 = std::numeric_limits<double>::lowest();
         for(i = 0; i < n; i++) {
             idI = I[i];
             if(visited[idI] == 1) {

--- a/tabu/src/bqpSolver.h
+++ b/tabu/src/bqpSolver.h
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <time.h>
 #include <math.h>
+#include <vector>
 #include "bqpUtil.h"
 
 #define LAMBDA 5000
@@ -40,7 +41,7 @@ typedef struct bqpSolver_Callback {
  * \param timLimitInMilliSecs: time limit in milli seconds
  * \return best solution found
  */
-double bqpSolver_tabooSearch(BQP *bqp, int *starting, double startingObjective, int tt, long long ZCoeff, long long timeLimitInMilliSecs, const bqpSolver_Callback *callback);
+double bqpSolver_tabooSearch(BQP *bqp, std::vector<int> &starting, double startingObjective, int tt, long long ZCoeff, long long timeLimitInMilliSecs, const bqpSolver_Callback *callback);
 
 /**
  * Solves a BQP using basic local searching
@@ -50,7 +51,7 @@ double bqpSolver_tabooSearch(BQP *bqp, int *starting, double startingObjective, 
  * \param changeInObjective: Partial derivative values for the starting solution
  * \return best solution found
  */
-double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObjective, double *changeInObjective);
+double bqpSolver_localSearchInternal(BQP *bqp, std::vector<int> &starting, double startingObjective, std::vector<double> &changeInObjective);
 
 /**
  * Solves a BQP using basic local searching (wrapper for localSearchInternal)
@@ -59,7 +60,7 @@ double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObj
  * \param starting: A starting solution
  * \return best solution found
  */
-double bqpSolver_localSearch(BQP *bqp, int *starting);
+double bqpSolver_localSearch(BQP *bqp, std::vector<int> &starting);
 
 /**
  * Helper function to bqpSolver_multiStartTabooSearch() function
@@ -70,7 +71,7 @@ double bqpSolver_localSearch(BQP *bqp, int *starting);
  * \param I: storage for selected variables
  * \return 
  */
-void bqpSolver_selectVariables(BQP *bqp, int n, double **C, int *I);
+void bqpSolver_selectVariables(BQP *bqp, int n, std::vector< std::vector<double> > &C, std::vector<int> &I);
 
 /**
  * Helper function to bqpSolver_multiStartTabooSearch() function
@@ -82,7 +83,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, double **C, int *I);
  * \param n: number of variables required to be selected
  * \return 
  */
-void bqpSolver_steepestAscent(int *solution, BQP *bqp, double **C, int *I, int n);
+void bqpSolver_steepestAscent(std::vector<int> &solution, BQP *bqp, std::vector< std::vector<double> > &C, std::vector<int> &I, int n);
 
 /**
  * Compute the C matrix (refer to the tabu search heuristic in the paper by Palubeckis
@@ -91,7 +92,7 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, double **C, int *I, int n
  * \param solution: current solution
  * \return void
  */
-void bqpSolver_computeC(double **C, BQP *bqp, int *solution);
+void bqpSolver_computeC(std::vector< std::vector<double> > &C, BQP *bqp, std::vector<int> &solution);
 
 /**
  * Simple tabu search solver with multi starts
@@ -100,7 +101,7 @@ void bqpSolver_computeC(double **C, BQP *bqp, int *solution);
  * \param numStarts: number of re starts
  * \return best solution found
  */
-double bqpSolver_multiStartTabooSearch(BQP *bqp, long long timeLimitInMilliSecs, int numStarts, int tabuTenure, const int *initSolution, const bqpSolver_Callback *callback);
+double bqpSolver_multiStartTabooSearch(BQP *bqp, long long timeLimitInMilliSecs, int numStarts, int tabuTenure, std::vector<int> const &initSolution, const bqpSolver_Callback *callback);
 
 /**
  * Exhaustive solver (takes too long for problems with more than 20 variables)
@@ -119,7 +120,7 @@ double bqpSolver_naiveSearch(BQP *bqp);
  * \param changeInObjective: Partial derivative values for the starting solution
  * \return best solution found
  */
-double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, double startingObjective, double *changeInObjective);
+double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, std::vector<int> &starting, std::vector<int> &restricted, double startingObjective, std::vector<double> &changeInObjective);
 
 /**
  * Another version to bqpSolver_localSearch() function
@@ -129,7 +130,7 @@ double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *res
  * \param restricted: Tells if a variable is restricted or not
  * \return best solution found
  */
-double bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted);
+double bqpSolver_restrictedLocalSearch(BQP *bqp, std::vector<int> &starting, std::vector<int> &restricted);
 
 
 

--- a/tabu/src/bqpSolver.h
+++ b/tabu/src/bqpSolver.h
@@ -26,8 +26,6 @@
 #define LAMBDA 5000
 #define ALPHA 0.4
 
-#define LARGE_NUMBER 999999999
-
 
 typedef struct bqpSolver_Callback {
   void (*func)(const struct bqpSolver_Callback *callback, BQP *bqp);
@@ -42,7 +40,7 @@ typedef struct bqpSolver_Callback {
  * \param timLimitInMilliSecs: time limit in milli seconds
  * \return best solution found
  */
-long bqpSolver_tabooSearch(BQP *bqp, int *starting, long startingObjective, int tt, long long ZCoeff, long long timeLimitInMilliSecs, const bqpSolver_Callback *callback);
+double bqpSolver_tabooSearch(BQP *bqp, int *starting, double startingObjective, int tt, long long ZCoeff, long long timeLimitInMilliSecs, const bqpSolver_Callback *callback);
 
 /**
  * Solves a BQP using basic local searching
@@ -52,7 +50,7 @@ long bqpSolver_tabooSearch(BQP *bqp, int *starting, long startingObjective, int 
  * \param changeInObjective: Partial derivative values for the starting solution
  * \return best solution found
  */
-long bqpSolver_localSearchInternal(BQP *bqp, int *starting, long startingObjective, long *changeInObjective);
+double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObjective, double *changeInObjective);
 
 /**
  * Solves a BQP using basic local searching (wrapper for localSearchInternal)
@@ -61,7 +59,7 @@ long bqpSolver_localSearchInternal(BQP *bqp, int *starting, long startingObjecti
  * \param starting: A starting solution
  * \return best solution found
  */
-long bqpSolver_localSearch(BQP *bqp, int *starting);
+double bqpSolver_localSearch(BQP *bqp, int *starting);
 
 /**
  * Helper function to bqpSolver_multiStartTabooSearch() function
@@ -72,7 +70,7 @@ long bqpSolver_localSearch(BQP *bqp, int *starting);
  * \param I: storage for selected variables
  * \return 
  */
-void bqpSolver_selectVariables(BQP *bqp, int n, long **C, int *I);
+void bqpSolver_selectVariables(BQP *bqp, int n, double **C, int *I);
 
 /**
  * Helper function to bqpSolver_multiStartTabooSearch() function
@@ -84,7 +82,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, long **C, int *I);
  * \param n: number of variables required to be selected
  * \return 
  */
-void bqpSolver_steepestAscent(int *solution, BQP *bqp, long **C, int *I, int n);
+void bqpSolver_steepestAscent(int *solution, BQP *bqp, double **C, int *I, int n);
 
 /**
  * Compute the C matrix (refer to the tabu search heuristic in the paper by Palubeckis
@@ -93,7 +91,7 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, long **C, int *I, int n);
  * \param solution: current solution
  * \return void
  */
-void bqpSolver_computeC(long **C, BQP *bqp, int *solution);
+void bqpSolver_computeC(double **C, BQP *bqp, int *solution);
 
 /**
  * Simple tabu search solver with multi starts
@@ -102,14 +100,14 @@ void bqpSolver_computeC(long **C, BQP *bqp, int *solution);
  * \param numStarts: number of re starts
  * \return best solution found
  */
-long bqpSolver_multiStartTabooSearch(BQP *bqp, long long timeLimitInMilliSecs, int numStarts, int tabuTenure, const int *initSolution, const bqpSolver_Callback *callback);
+double bqpSolver_multiStartTabooSearch(BQP *bqp, long long timeLimitInMilliSecs, int numStarts, int tabuTenure, const int *initSolution, const bqpSolver_Callback *callback);
 
 /**
  * Exhaustive solver (takes too long for problems with more than 20 variables)
  * \param bqp: BQP problem to be solved
  * \return 
  */
-int bqpSolver_naiveSearch(BQP *bqp);
+double bqpSolver_naiveSearch(BQP *bqp);
 
 /**
  * Another version for bqpSolver_localSearchInternal() function
@@ -121,7 +119,7 @@ int bqpSolver_naiveSearch(BQP *bqp);
  * \param changeInObjective: Partial derivative values for the starting solution
  * \return best solution found
  */
-long bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, long startingObjective, long *changeInObjective);
+double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, double startingObjective, double *changeInObjective);
 
 /**
  * Another version to bqpSolver_localSearch() function
@@ -131,7 +129,7 @@ long bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restr
  * \param restricted: Tells if a variable is restricted or not
  * \return best solution found
  */
-long bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted);
+double bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted);
 
 
 

--- a/tabu/src/bqpUtil.cpp
+++ b/tabu/src/bqpUtil.cpp
@@ -49,7 +49,7 @@ void bqpUtil_print(BQP *bqp) {
     for(i = 0; i < bqp->nVars; i++) {
         printf("{");
         for(j = 0; j < bqp->nVars; j++) {
-            printf("%6ld,", bqp->Q[i][j]);
+            printf("%f,", bqp->Q[i][j]);
         }
         printf("},\n");
     }
@@ -123,7 +123,7 @@ void bqpUtil_randomizeBQPSolution(BQP *bqp) {
 
 void bqpUtil_printSolution(BQP *bqp) {
     int i;
-    printf("Objective function value: %ld\n", bqpUtil_getObjective(bqp, bqp->solution));
+    printf("Objective function value: %f\n", bqpUtil_getObjective(bqp, bqp->solution));
     printf("Variable assignment:\n");
     for(i = 0; i < bqp->nVars; i++) {
         printf("%d ", bqp->solution[i]);

--- a/tabu/src/bqpUtil.cpp
+++ b/tabu/src/bqpUtil.cpp
@@ -56,7 +56,7 @@ void bqpUtil_print(BQP *bqp) {
     printf("}\n");
 }
 
-double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) {
+double bqpUtil_getChangeInObjective(BQP *bqp, vector<int> &oldSolution, int flippedBit) {
     int i;
     double change = 0, inc;
     change += (oldSolution[flippedBit] == 1)? (-1 * bqp->Q[flippedBit][flippedBit]) : bqp->Q[flippedBit][flippedBit];
@@ -69,11 +69,10 @@ double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) 
     return change;
 }
 
-double bqpUtil_getObjective(BQP *bqp, int * solution) {
+double bqpUtil_getObjective(BQP *bqp, vector<int> &solution) {
     int i;
     double cost = 0;
-    vector<int> u_zeroSol(bqp->nVars);
-    int *zeroSolution = vector_data<int>(u_zeroSol);
+    vector<int> zeroSolution(bqp->nVars);
     for(i = bqp->nVars; i--;) {
         zeroSolution[i] = 0;
     }
@@ -86,11 +85,10 @@ double bqpUtil_getObjective(BQP *bqp, int * solution) {
     return cost;
 }
 
-double bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, double oldCost) {
+double bqpUtil_getObjectiveIncremental(BQP *bqp, vector<int> &solution, vector<int> &oldSolution, double oldCost) {
     int i;
     double cost = oldCost;
-    vector<int> u_old(bqp->nVars);
-    int *oldSolCopy = vector_data<int>(u_old);
+    vector<int> oldSolCopy(bqp->nVars);
     for(i = 0; i < bqp->nVars; i++) {
         oldSolCopy[i] = oldSolution[i];
     }
@@ -103,17 +101,9 @@ double bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution
     return cost;
 }
 
-void bqpUtil_initBQPSolution(BQP *bqp, const int *initSolution) {
-    int i;
-
-    if (initSolution == NULL) {
-      for(i = 0; i < bqp->nVars; i++) {
-          bqp->solution[i] = 0;
-      }
-    } else {
-      memcpy(vector_data<int>(bqp->solution), initSolution, bqp->nVars * sizeof(int));
-    }
-    bqp->solutionQuality = bqpUtil_getObjective(bqp, vector_data<int>(bqp->solution));
+void bqpUtil_initBQPSolution(BQP *bqp, vector<int> const &initSolution) {
+    bqp->solution = initSolution;
+    bqp->solutionQuality = bqpUtil_getObjective(bqp, bqp->solution);
     bqp->nIterations = 1;
 }
 
@@ -128,12 +118,12 @@ void bqpUtil_randomizeBQPSolution(BQP *bqp) {
         }
     }
     bqp->nIterations = 1;
-    bqp->solutionQuality = bqpUtil_getObjective(bqp, vector_data<int>(bqp->solution));
+    bqp->solutionQuality = bqpUtil_getObjective(bqp, bqp->solution);
 }
 
 void bqpUtil_printSolution(BQP *bqp) {
     int i;
-    printf("Objective function value: %ld\n", bqpUtil_getObjective(bqp, vector_data<int>(bqp->solution)));
+    printf("Objective function value: %ld\n", bqpUtil_getObjective(bqp, bqp->solution));
     printf("Variable assignment:\n");
     for(i = 0; i < bqp->nVars; i++) {
         printf("%d ", bqp->solution[i]);

--- a/tabu/src/bqpUtil.cpp
+++ b/tabu/src/bqpUtil.cpp
@@ -19,9 +19,9 @@
 
 using std::vector;
 
-long bqpUtil_getMaxBQPCoeff(BQP *bqp) {
+double bqpUtil_getMaxBQPCoeff(BQP *bqp) {
     int i, j;
-    long M = bqp->Q[0][0];
+    double M = bqp->Q[0][0];
     for(i = 0; i < bqp->nVars; i++) {
         for(j = 0; j < bqp->nVars; j++) {
             if(M < abs(bqp->Q[i][j])) {
@@ -56,9 +56,9 @@ void bqpUtil_print(BQP *bqp) {
     printf("}\n");
 }
 
-long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) {
+double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) {
     int i;
-    long change = 0, inc;
+    double change = 0, inc;
     change += (oldSolution[flippedBit] == 1)? (-1 * bqp->Q[flippedBit][flippedBit]) : bqp->Q[flippedBit][flippedBit];
     for(i = bqp->nVars; i--;) {
         if(!(oldSolution[i] ^ 1) && i ^ flippedBit) {
@@ -69,9 +69,9 @@ long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) {
     return change;
 }
 
-long bqpUtil_getObjective(BQP *bqp, int * solution) {
+double bqpUtil_getObjective(BQP *bqp, int * solution) {
     int i;
-    long cost = 0;
+    double cost = 0;
     vector<int> u_zeroSol(bqp->nVars);
     int *zeroSolution = vector_data<int>(u_zeroSol);
     for(i = bqp->nVars; i--;) {
@@ -86,9 +86,9 @@ long bqpUtil_getObjective(BQP *bqp, int * solution) {
     return cost;
 }
 
-long bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, long oldCost) {
+double bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, double oldCost) {
     int i;
-    long cost = oldCost;
+    double cost = oldCost;
     vector<int> u_old(bqp->nVars);
     int *oldSolCopy = vector_data<int>(u_old);
     for(i = 0; i < bqp->nVars; i++) {

--- a/tabu/src/bqpUtil.h
+++ b/tabu/src/bqpUtil.h
@@ -75,7 +75,7 @@ void bqpUtil_print(BQP *bqp);
  * @param flippedBit: the bit that is flipped
  * @return change in objective
  */
-double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
+double bqpUtil_getChangeInObjective(BQP *bqp, std::vector<int> &oldSolution, int flippedBit);
 
 /**
  * Computes the value of objective function of a BQP for a given solution
@@ -83,7 +83,7 @@ double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
  * @param solution: given solution
  * @return value of objective function
  */
-double bqpUtil_getObjective(BQP *bqp, int * solution);
+double bqpUtil_getObjective(BQP *bqp, std::vector<int> & solution);
 
 /**
  * Computes the value of objective function of a BQP for a given solution,
@@ -97,14 +97,14 @@ double bqpUtil_getObjective(BQP *bqp, int * solution);
  * @param oldCost: value of objective function at old solution
  * @return value ot objective function at new solution
  */
-double bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, long oldCost);
+double bqpUtil_getObjectiveIncremental(BQP *bqp, std::vector<int> &solution, std::vector<int> &oldSolution, long oldCost);
 
 /**
  * Initialize the current solution in a BQP to all zeros
  * @param bqp: the BQP
  * @return void
  */
-void bqpUtil_initBQPSolution(BQP *bqp, const int *initSolution);
+void bqpUtil_initBQPSolution(BQP *bqp, std::vector<int> const &initSolution);
 
 /**
  * Initialize the current solution in a BQP randomly
@@ -126,12 +126,5 @@ void bqpUtil_free(BQP *bqp);
  * @return void
  */
 void bqpUtil_printSolution(BQP *bqp);
-
-// replacement for vector.data() in ancient compilers not supporting it (VS2008, aka VS9)
-// NB: we need to support VS9 is we want to build for python2.7 on windows
-template<typename T>
-T* vector_data(std::vector<T>& v) {
-    return v.size() ? &v[0] : NULL;
-}
 
 #endif

--- a/tabu/src/bqpUtil.h
+++ b/tabu/src/bqpUtil.h
@@ -32,16 +32,16 @@
  * nIterations: number of iterations required to arrive at this solution
  */
 typedef struct {
-	std::vector<std::vector<long> >Q;
+	std::vector<std::vector<double> >Q;
 	int nVars;
 	std::vector<int> solution;
-	long solutionQuality;
+	double solutionQuality;
 	unsigned long long nIterations;
 	/*added to record more statistics.*/
 	unsigned long long restartNum;
 	unsigned long long iterNum;
 	unsigned long long evalNum;
-	long upperBound;
+	double upperBound;
 } BQP;
 
 
@@ -50,7 +50,7 @@ typedef struct {
  * @param bqp
  * @return maximum Q[i][j]
  */
-long bqpUtil_getMaxBQPCoeff(BQP *bqp);
+double bqpUtil_getMaxBQPCoeff(BQP *bqp);
 
 /**
  * converts a generic bqp Q matrix into upper trianglular using:
@@ -75,7 +75,7 @@ void bqpUtil_print(BQP *bqp);
  * @param flippedBit: the bit that is flipped
  * @return change in objective
  */
-long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
+double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
 
 /**
  * Computes the value of objective function of a BQP for a given solution
@@ -83,7 +83,7 @@ long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
  * @param solution: given solution
  * @return value of objective function
  */
-long bqpUtil_getObjective(BQP *bqp, int * solution);
+double bqpUtil_getObjective(BQP *bqp, int * solution);
 
 /**
  * Computes the value of objective function of a BQP for a given solution,
@@ -97,7 +97,7 @@ long bqpUtil_getObjective(BQP *bqp, int * solution);
  * @param oldCost: value of objective function at old solution
  * @return value ot objective function at new solution
  */
-long bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, long oldCost);
+double bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, long oldCost);
 
 /**
  * Initialize the current solution in a BQP to all zeros

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -43,7 +43,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
     bqp.nVars = nvars;
     bqp.restartNum = 0;
     bqp.Q.resize(nvars);
-    bqp.upperBound = std::numeric_limits<long>::min();
+    bqp.upperBound = std::numeric_limits<double>::min();
     for (int i = 0; i < nvars; i++)
         bqp.Q[i].resize(nvars);
 
@@ -51,7 +51,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
         for (int j = i; j < nvars; j++){
             if (Q[i][j] != Q[j][i])
                 throw Exception("Q must be symmetric");
-            bqp.Q[i][j] = bqp.Q[j][i] = (long) (Q[i][j] * scaleFactor);
+            bqp.Q[i][j] = bqp.Q[j][i] = Q[i][j]; //(long) (Q[i][j] * scaleFactor);
         }
     }
     bqp.solution.resize(nvars);
@@ -62,7 +62,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
 
 double TabuSearch::bestEnergy()
 {
-    return (double)bqpUtil_getObjective(&bqp, vector_data<int>(bqp.solution)) / sf;
+    return bqpUtil_getObjective(&bqp, vector_data<int>(bqp.solution)) / sf;
 }
 
 vector<int> TabuSearch::bestSolution()

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -39,7 +39,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
     bqp.nVars = nvars;
     bqp.restartNum = 0;
     bqp.Q.resize(nvars);
-    bqp.upperBound = std::numeric_limits<double>::lowest();
+    bqp.upperBound = -std::numeric_limits<double>::max();
     for (int i = 0; i < nvars; i++)
         bqp.Q[i].resize(nvars);
 

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -20,17 +20,13 @@
 using std::vector;
 using std::size_t;
 
-TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int tenure, int scaleFactor, long int timeout):
-    sf(scaleFactor)
+TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int tenure, long int timeout)
 {
     size_t nvars = Q.size();
     for (int i = 0; i < nvars; i++){
         if (Q[i].size() != nvars)
             throw Exception("Q must be a symmetric square matrix");
     }
-    if (scaleFactor < 0)
-        throw Exception("scaleFactor must be a positive integer");
-
     if (initSol.size() != nvars)
         throw Exception("length of init_solution doesn't match the size of Q");
 
@@ -51,7 +47,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
         for (int j = i; j < nvars; j++){
             if (Q[i][j] != Q[j][i])
                 throw Exception("Q must be symmetric");
-            bqp.Q[i][j] = bqp.Q[j][i] = Q[i][j]; //(long) (Q[i][j] * scaleFactor);
+            bqp.Q[i][j] = bqp.Q[j][i] = Q[i][j];
         }
     }
     bqp.solution.resize(nvars);
@@ -62,7 +58,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
 
 double TabuSearch::bestEnergy()
 {
-    return bqpUtil_getObjective(&bqp, vector_data<int>(bqp.solution)) / sf;
+    return bqpUtil_getObjective(&bqp, vector_data<int>(bqp.solution));
 }
 
 vector<int> TabuSearch::bestSolution()

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -39,7 +39,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
     bqp.nVars = nvars;
     bqp.restartNum = 0;
     bqp.Q.resize(nvars);
-    bqp.upperBound = std::numeric_limits<double>::min();
+    bqp.upperBound = std::numeric_limits<double>::lowest();
     for (int i = 0; i < nvars; i++)
         bqp.Q[i].resize(nvars);
 

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -52,13 +52,13 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
     }
     bqp.solution.resize(nvars);
     bqp.solutionQuality = 0;
-    bqpSolver_multiStartTabooSearch(&bqp, timeout, 1000000, tenure, vector_data<int>(initSol), NULL);
+    bqpSolver_multiStartTabooSearch(&bqp, timeout, 1000000, tenure, initSol, NULL);
 }
 
 
 double TabuSearch::bestEnergy()
 {
-    return bqpUtil_getObjective(&bqp, vector_data<int>(bqp.solution));
+    return bqpUtil_getObjective(&bqp, bqp.solution);
 }
 
 vector<int> TabuSearch::bestSolution()

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -22,12 +22,12 @@ using std::size_t;
 
 TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int tenure, long int timeout)
 {
-    size_t nvars = Q.size();
+    int nvars = Q.size();
     for (int i = 0; i < nvars; i++){
-        if (Q[i].size() != nvars)
+        if ((int)Q[i].size() != nvars)
             throw Exception("Q must be a symmetric square matrix");
     }
-    if (initSol.size() != nvars)
+    if ((int)initSol.size() != nvars)
         throw Exception("length of init_solution doesn't match the size of Q");
 
     if (tenure < 0 || tenure > (nvars - 1))

--- a/tabu/src/tabu_search.h
+++ b/tabu/src/tabu_search.h
@@ -22,13 +22,12 @@
 class TabuSearch
 {
     public:
-        TabuSearch(std::vector<std::vector<double> > Q, std::vector<int> initSol, int tenure, int scaleFactor, long int timeout);
+        TabuSearch(std::vector<std::vector<double> > Q, std::vector<int> initSol, int tenure, long int timeout);
         double bestEnergy();
         std::vector<int> bestSolution();
 
     private:
         BQP bqp;
-        int sf;
 };
 
 #endif

--- a/tabu/tabu_search.i
+++ b/tabu/tabu_search.i
@@ -32,15 +32,13 @@ namespace std {
 %define TABU_DOCSTRING
 "Tabu Search
 
-handler = TabuSearch(q, init_solution, tenure, scaleFactor, timeout)
+handler = TabuSearch(q, init_solution, tenure, timeout)
 
     Args:
         q: QUBO as a list of list, or numpy matrix of double (float64) values.
            q must be symmetric.
         init_solution: List of 0/1 values, which defines the initial state of each variable.
         tenure: Tabu tenure. min(20, num_vars / 4) seems to be a good choice.
-        scaleFactor: Scaling factor for elements of q. The elements of q are stored as long ints using
-                     internal_q = long int (q * scaleFactor).
         timeout: Total running time in milliseconds.
 
 energy = handler.bestEnergy()


### PR DESCRIPTION
Fixes #29 as the `scale_factor` parameter is no longer necessary and has been removed.