### PR TITLE
Fix doctest fail for sphinx2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'recommonmark',
 ]
 
 autosummary_generate = True
@@ -48,13 +49,13 @@ autosummary_generate = True
 # You can specify multiple suffix as a list of string:
 #
 source_suffix = ['.rst', '.md']
-source_parsers = {'.md': 'recommonmark.parser.CommonMarkParser'}
+#source_parsers = {'.md': 'recommonmark.parser.CommonMarkParser'}
 
 # The master toctree document.
 master_doc = 'index'
 
 # Mock the C++ extension
-autodoc_mock_imports = ["tabu.tabu_search"]
+autodoc_mock_imports = ["tabu.src.tabu_search"]
 
 # Load package info, without importing the package
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 -r ../requirements.txt
-sphinx<2.0.0
 sphinx_rtd_theme
 recommonmark

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 -r ../requirements.txt
+sphinx
 sphinx_rtd_theme
 recommonmark


### PR DESCRIPTION
closes #35 

```
snowballstemmer               1.2.1
Sphinx                        2.0.0
sphinx-rtd-theme              0.4.0
```
and 
```
Doctest summary
===============
   14 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded.
```