### PR TITLE
Fix docs build on RtD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: doctest
           command: |
             . env/bin/activate
-            pip install .
+            python setup.py build_ext --inplace
             pip install -r docs/requirements.txt
             make -C docs/ doctest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: doctest
           command: |
             . env/bin/activate
-            python setup.py build_ext --inplace
+            python setup.py install
             pip install -r docs/requirements.txt
             make -C docs/ doctest
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+
+# build docs in additional formats such as PDF and ePub
+formats: all
+
+# python version and requirements
+python:
+  version: 3.7
+  install:
+    # standard docs requirements
+    - requirements: docs/requirements.txt
+
+    # run `python ./setup.py install` and build & install tabu extension
+    - method: setuptools
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,6 @@ from io import open
 import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # -- General configuration ------------------------------------------------
 # import sphinx
@@ -53,10 +52,6 @@ source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'
-
-# Mock the C++ extension on RtD (where we can't build_ext)
-if os.getenv('READTHEDOCS'):
-    autodoc_mock_imports = ["tabu.tabu_search"]
 
 # Load package info, without importing the package
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,8 +54,9 @@ source_suffix = ['.rst', '.md']
 # The master toctree document.
 master_doc = 'index'
 
-# Mock the C++ extension
-autodoc_mock_imports = ["tabu.tabu_search"]
+# Mock the C++ extension on RtD (where we can't build_ext)
+if os.getenv('READTHEDOCS'):
+    autodoc_mock_imports = ["tabu.tabu_search"]
 
 # Load package info, without importing the package
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # Mock the C++ extension
-autodoc_mock_imports = ["tabu.src.tabu_search"]
+autodoc_mock_imports = ["tabu.tabu_search"]
 
 # Load package info, without importing the package
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 import os
 from io import open
 from setuptools import setup, Extension
+from setuptools.command.build_py import build_py
 
 
 # Load package info, without importing the package
@@ -26,6 +27,14 @@ try:
         exec(f.read(), package_info)
 except SyntaxError:
     execfile(package_info_path, package_info)
+
+
+# Custom build command that runs `build_ext` before `build_py`, so that
+# SWIG-generated modules (in build_ext) are included in package (build_py).
+class build_ext_before_py(build_py):
+    def run(self):
+        self.run_command("build_ext")
+        return build_py.run(self)
 
 
 packages = ['tabu']
@@ -54,6 +63,8 @@ extras_require = {
     'test': ['coverage'],
 }
 
+cmdclass = {'build_py': build_ext_before_py}
+
 setup(
     name=package_info['__packagename__'],
     version=package_info['__version__'],
@@ -63,6 +74,7 @@ setup(
     long_description=open(os.path.join(basedir, 'README.rst'), encoding='utf-8').read(),
     url=package_info['__url__'],
     license=package_info['__license__'],
+    cmdclass=cmdclass,
     ext_modules=ext_modules,
     py_modules=py_modules,
     packages=packages,


### PR DESCRIPTION
The bug was introduced in e3b590de.

If `tabu.tabu_search` file is not properly mocked while building docs
with:
```
autodoc_mock_imports = ["tabu.tabu_search"]
```
`TabuSampler` import fails (and the docstring is not compiled).

The reason we need to mock it is because otherwise we would need to
build it. And to build it, we need `swig`, which is not available on RtD
(see #25). The only alternative IIRC is to roll out our docker build
container.