### PR TITLE
Docs build on RtD workaround (mock tabu C ext)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,8 @@ jobs:
           name: doctest
           command: |
             . env/bin/activate
-            python setup.py install
             pip install -r docs/requirements.txt
+            python setup.py install
             make -C docs/ doctest
 
       - run: &sdist-build-template

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,3 @@ python:
   install:
     # standard docs requirements
     - requirements: docs/requirements.txt
-
-    # run `python ./setup.py install` and build & install tabu extension
-    - method: setuptools
-      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ from io import open
 import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # -- General configuration ------------------------------------------------
 # import sphinx
@@ -52,6 +53,10 @@ source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'
+
+# Mock the C++ extension on RtD (where we can't build_ext)
+if os.getenv('READTHEDOCS'):
+    autodoc_mock_imports = ["tabu.tabu_search"]
 
 # Load package info, without importing the package
 basedir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/setup.py
+++ b/setup.py
@@ -80,4 +80,5 @@ setup(
     packages=packages,
     install_requires=install_requires,
     extras_require=extras_require,
+    zip_safe=False,
 )


### PR DESCRIPTION
Note: in sphinx conf.py, we append project root so that is extension is
compiled and installed in the env, doctests will work.

On RtD, extension is not installed, so sphinx imports from source files,
but we mock the imports that would fail in that case.