### PR TITLE
Publish binary wheels for macOS 10.9+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
 
   test-osx-3.8: &osx-tests-template
     macos:
-      xcode: "11.1.0"
+      xcode: "11.2.1"
     environment:
       PYTHON: 3.8.0
 
@@ -296,7 +296,7 @@ jobs:
 
   build-osx-3.8: &osx-build-template
     macos:
-      xcode: "11.1.0"
+      xcode: "11.2.1"
     environment:
       PYTHON: 3.8.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,12 @@ jobs:
       xcode: "11.2.1"
     environment:
       PYTHON: 3.8.0
+      HOMEBREW_NO_AUTO_UPDATE: 1
+
+      # Force (lie about) macOS 10.9 binary compatibility.
+      # Needed for properly versioned wheels.
+      # See: https://github.com/MacPython/wiki/wiki/Spinning-wheels
+      MACOSX_DEPLOYMENT_TARGET: 10.9
 
     working_directory: ~/repo
 
@@ -171,30 +177,35 @@ jobs:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.7.4
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-3.6:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.6.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-3.5:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.5.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-3.4:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.4.8
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-2.7:
     <<: *osx-tests-template
     environment:
       PYTHON: 2.7.15
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   cpp-tests:
@@ -299,6 +310,8 @@ jobs:
       xcode: "11.2.1"
     environment:
       PYTHON: 3.8.0
+      MACOSX_DEPLOYMENT_TARGET: 10.9
+      HOMEBREW_NO_AUTO_UPDATE: 1
 
     working_directory: ~/repo
 
@@ -359,30 +372,35 @@ jobs:
     <<: *osx-build-template
     environment:
       PYTHON: 3.7.4
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-3.6:
     <<: *osx-build-template
     environment:
       PYTHON: 3.6.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-3.5:
     <<: *osx-build-template
     environment:
       PYTHON: 3.5.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-3.4:
     <<: *osx-build-template
     environment:
       PYTHON: 3.4.8
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-2.7:
     <<: *osx-build-template
     environment:
       PYTHON: 2.7.15
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
             . env/bin/activate
             python setup.py build_ext --inplace
-        
+
       - run: &run-tests-template
           name: run unittests
           command: |
@@ -70,6 +70,12 @@ jobs:
           command: |
             . env/bin/activate
             python setup.py sdist
+
+      - run: &wheel-build-template
+          name: create bdist_wheel
+          command: |
+            . env/bin/activate
+            python setup.py bdist_wheel
 
       - store_artifacts:
           path: ./dist
@@ -169,6 +175,8 @@ jobs:
       - run: *run-tests-template
 
       - run: *sdist-build-template
+
+      - run: *wheel-build-template
 
       - store_artifacts:
           path: ./dist
@@ -354,12 +362,7 @@ jobs:
 
       - run: *install-package-template
         
-      - run:
-          name: create bdist_wheel
-          command: |
-            . env/bin/activate
-            python setup.py build_ext --inplace
-            python setup.py bdist_wheel
+      - run: *wheel-build-template
 
       - store_artifacts:
           path: ./dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1
 
       - run:
           name: install python
@@ -133,7 +133,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1
 
       - run:
           name: install swig


### PR DESCRIPTION
For compatibility with older macOSes our wheels should be built for 10.6 or 10.9.