### PR TITLE
Use float instead of int for storing biases

### DIFF
--- a/tabu/sampler.py
+++ b/tabu/sampler.py
@@ -47,14 +47,13 @@ class TabuSampler(dimod.Sampler):
 
     def __init__(self):
         self.parameters = {'tenure': [],
-                           'scale_factor': [],
                            'timeout': [],
                            'num_reads': [],
                            'init_solution': []}
         self.properties = {}
 
     def sample(self, bqm, initial_states=None, initial_states_generator='random',
-               num_reads=None, tenure=None, timeout=20, scale_factor=1, **kwargs):
+               num_reads=None, tenure=None, timeout=20, **kwargs):
         """Run Tabu search on a given binary quadratic model.
 
         Args:
@@ -97,11 +96,6 @@ class TabuSampler(dimod.Sampler):
 
             timeout (int, optional):
                 Total running time in milliseconds.
-
-            scale_factor (number, optional):
-                Scaling factor for linear and quadratic biases in the BQM. Internally, the BQM is
-                converted to a QUBO matrix, and elements are stored as long ints
-                using ``internal_q = long int (q * scale_factor)``.
 
             init_solution (:class:`~dimod.SampleSet`, optional):
                 Deprecated. Alias for `initial_states`.
@@ -179,7 +173,7 @@ class TabuSampler(dimod.Sampler):
         samples = numpy.empty((num_reads, len(bqm)), dtype=numpy.int8)
         for ni in range(num_reads):
             init_solution = self._bqm_sample_to_tabu_solution(next(init_sample_generator), varorder)
-            r = TabuSearch(qubo, init_solution, tenure, scale_factor, timeout)
+            r = TabuSearch(qubo, init_solution, tenure, timeout)
             samples[ni, :] = r.bestSolution()
 
         if bqm.vartype is dimod.SPIN:

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -151,16 +151,16 @@ double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObj
     bqp->solutionQuality = startingObjective;
     do {
         improved = 0;
-        for(i = 0; i < bqp->nVars; i++, iter++) {
+        for (i = 0; i < bqp->nVars; i++, iter++) {
             bqp->evalNum++; /*added to record more statistics.*/
-            if(changeInObjective[i] < 0) {
+            if (changeInObjective[i] < 0) {
                 bqp->solution[i] = 1 - bqp->solution[i];
                 bqp->solutionQuality = bqp->solutionQuality + changeInObjective[i];
                 improved = 1;
                 changeInObjective[i] = -changeInObjective[i];
-                for(j = 0; j < bqp->nVars; j++) {
-                    change = bqp->Q[i][j] + bqp->Q[j][i];
-                    if(change && (j ^ i)) {
+                for (j = 0; j < bqp->nVars; j++) {
+                    if (j != i) {
+                        change = bqp->Q[i][j] + bqp->Q[j][i];
                         changeInObjective[j] += (bqp->solution[j] ^ bqp->solution[i])? change : -change;
                     }
                 }

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 #include <vector>
+#include <limits>
 #include "bqpSolver.h"
 
 using std::vector;

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -203,7 +203,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<double> > &C, int 
     }
     for(ctr = 0; ctr < n; ctr++) {
         dmin = std::numeric_limits<double>::max();
-        dmax = std::numeric_limits<double>::lowest();
+        dmax = -std::numeric_limits<double>::max();
         allDsEqual = 1;
         for(i = 0; i < bqp->nVars; i++) {
             if(selected[i] == 1) {
@@ -316,8 +316,8 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<double> > &
         h2[idI] = h2[idI] * 1;
     }
     for(ctr = 0; ctr < n; ctr++) {
-        V1 = std::numeric_limits<double>::lowest();
-        V2 = std::numeric_limits<double>::lowest();
+        V1 = -std::numeric_limits<double>::max();
+        V2 = -std::numeric_limits<double>::max();
         for(i = 0; i < n; i++) {
             idI = I[i];
             if(visited[idI] == 1) {

--- a/tabu/src/bqpSolver.cpp
+++ b/tabu/src/bqpSolver.cpp
@@ -17,10 +17,10 @@
 
 using std::vector;
 
-long bqpSolver_tabooSearch(
+double bqpSolver_tabooSearch(
     BQP *bqp,
     int *starting,
-    long startingObjective,
+    double startingObjective,
     int tt,
     long long ZCoeff,
     long long timeLimitInMilliSecs,
@@ -28,26 +28,26 @@ long bqpSolver_tabooSearch(
 ) {
     bqp->restartNum++;/*added to record more statistics.*/
     long long startTime = realtime_clock();
-    int i, k, j;
+    int i, k;
     int globalMinFound;
     long /*objectiveChangeCtr = 0,*/ localSearchCtr = 0;
     long long iter = 0;
     int bestK;
-    long localMinCost, cost = 0;
-    long prevCost;
+    double localMinCost, cost = 0;
+    double prevCost;
     vector<int> u_tabu(bqp->nVars);
     int *taboo = vector_data<int>(u_tabu);
     vector<int> u_sol(bqp->nVars);
     int *solution = vector_data<int>(u_sol);
     int tabooTenure = (20 < (int)(bqp->nVars / 4.0))? 20 : (int)(bqp->nVars / 4.0);
     long long maxIter = (500000 > ZCoeff * (long long)bqp->nVars)? 500000 : ZCoeff * (long long)bqp->nVars;
-    vector<long> u_change(bqp->nVars);
-    long *changeInObjective = vector_data<long>(u_change), change;
+    vector<double> u_change(bqp->nVars);
+    double *changeInObjective = vector_data<double>(u_change), change;
 
     vector<int> u_tieList(bqp->nVars);
     int numTies = 0, *tieList = vector_data<int>(u_tieList);
 
-    if (tt > 0) {
+    if (tt > 0) { 
       tabooTenure = tt;
     }
 
@@ -61,7 +61,7 @@ long bqpSolver_tabooSearch(
     prevCost = bqp->solutionQuality;
     while(iter < maxIter && (realtime_clock() - startTime) < timeLimitInMilliSecs) {
         bqp->iterNum++; /*added to record more statistics.*/
-        localMinCost = LARGE_NUMBER;
+        localMinCost = std::numeric_limits<double>::max();
         bestK = -1;
         globalMinFound = 0;
         numTies = 0;
@@ -135,10 +135,10 @@ long bqpSolver_tabooSearch(
     return bqp->solutionQuality;
 }
 
-long bqpSolver_localSearchInternal(BQP *bqp, int *starting, long startingObjective, long *changeInObjective) {
+double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObjective, double *changeInObjective) {
     int i, j;
     long long iter = 0;
-    long objective, change;
+    double change;
     int improved;
     for(i = 0; i < bqp->nVars; i++) {
         bqp->solution[i] = starting[i];
@@ -166,10 +166,11 @@ long bqpSolver_localSearchInternal(BQP *bqp, int *starting, long startingObjecti
     return bqp->solutionQuality;
 }
 
-long bqpSolver_localSearch(BQP *bqp, int *starting) {
+// not currently used
+double bqpSolver_localSearch(BQP *bqp, int *starting) {
     int i;
-    vector<long> u_change(bqp->nVars);
-    long *changeInObjective = vector_data<long>(u_change);
+    vector<double> u_change(bqp->nVars);
+    double *changeInObjective = vector_data<double>(u_change);
     for(i = 0; i < bqp->nVars; i++) {
         changeInObjective[i] = bqpUtil_getChangeInObjective(bqp, starting, i);
     }
@@ -177,10 +178,10 @@ long bqpSolver_localSearch(BQP *bqp, int *starting) {
     return bqp->solutionQuality;
 }
 
-void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<long> > &C, int *I) {
+void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<double> > &C, int *I) {
     int i, ctr;
-    vector<long> u_d(bqp->nVars);
-    long *d = vector_data<long>(u_d);
+    vector<double> u_d(bqp->nVars);
+    double *d = vector_data<double>(u_d);
     vector<int> u_sel(bqp->nVars);
     int *selected = vector_data<int>(u_sel);
     int selectedVar = 0;
@@ -190,14 +191,14 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<long> > &C, int *I
     double *prob = vector_data<double>(u_prob);
     double selectedProb, prevProb, sumE;
     int allDsEqual;
-    long dmin, dmax;
+    double dmin, dmax;
     for(i = 0; i < bqp->nVars; i++) {
         selected[i] = 0;
         d[i] = C[i][i];
     }
     for(ctr = 0; ctr < n; ctr++) {
-        dmin = LARGE_NUMBER;
-        dmax = -LARGE_NUMBER;
+        dmin = std::numeric_limits<double>::max();
+        dmax = std::numeric_limits<double>::lowest();
         allDsEqual = 1;
         for(i = 0; i < bqp->nVars; i++) {
             if(selected[i] == 1) {
@@ -224,13 +225,13 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<long> > &C, int *I
                     continue;
                 }
                 if(d[i] <= 0 && dmin < 0) {
-                    e[i] = 1 - (double)d[i] / (double)dmin;
+                    e[i] = 1 - d[i] / dmin;
                 }
                 else if(d[i] == dmin && dmin == 0) {
                     e[i] = 0;
                 }
                 else {
-                    e[i] = 1 + LAMBDA * ((double)d[i] / (float)dmax);
+                    e[i] = 1 + LAMBDA * (d[i] / dmax);
                 }
             }
         }
@@ -279,20 +280,20 @@ void bqpSolver_selectVariables(BQP *bqp, int n, vector<vector<long> > &C, int *I
     }
 }
 
-void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<long> > &C, int *I, int n) {
+void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<double> > &C, int *I, int n) {
     int i, j, ctr;
     int idI, idJ, r, v = 0;
-    vector<long> u_h1(bqp->nVars);
-    vector<long> u_h2(bqp->nVars);
-    vector<long> u_q1(bqp->nVars);
-    vector<long> u_q2(bqp->nVars);
-    long *h1 = vector_data<long>(u_h1);
-    long *h2 = vector_data<long>(u_h2);
-    long *q1 = vector_data<long>(u_q1);
-    long *q2 = vector_data<long>(u_q2);
+    vector<double> u_h1(bqp->nVars);
+    vector<double> u_h2(bqp->nVars);
+    vector<double> u_q1(bqp->nVars);
+    vector<double> u_q2(bqp->nVars);
+    double *h1 = vector_data<double>(u_h1);
+    double *h2 = vector_data<double>(u_h2);
+    double *q1 = vector_data<double>(u_q1);
+    double *q2 = vector_data<double>(u_q2);
     vector<int> u_visited(bqp->nVars);
     int *visited = vector_data<int>(u_visited);
-    long V1, V2;
+    double V1, V2;
     for(i = 0; i < bqp->nVars; i++) {
         visited[i] = 0;
         solution[i] = 0;
@@ -310,8 +311,8 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<long> > &C,
         h2[idI] = h2[idI] * 1;
     }
     for(ctr = 0; ctr < n; ctr++) {
-        V1 = -LARGE_NUMBER;
-        V2 = -LARGE_NUMBER;
+        V1 = std::numeric_limits<double>::lowest();
+        V2 = std::numeric_limits<double>::lowest();
         for(i = 0; i < n; i++) {
             idI = I[i];
             if(visited[idI] == 1) {
@@ -349,7 +350,7 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, vector<vector<long> > &C,
     }
 }
 
-void bqpSolver_computeC(vector<vector<long> > &C, BQP *bqp, int *solution) {
+void bqpSolver_computeC(vector<vector<double> > &C, BQP *bqp, int *solution) {
     int i, j;
     for(i = 0; i < bqp->nVars; i++) {
         C[i][i] = -bqp->Q[i][i];
@@ -364,7 +365,7 @@ void bqpSolver_computeC(vector<vector<long> > &C, BQP *bqp, int *solution) {
     }
 }
 
-long bqpSolver_multiStartTabooSearch(
+double bqpSolver_multiStartTabooSearch(
     BQP *bqp,
     long long timeLimitInMilliSecs,
     int numStarts,
@@ -372,18 +373,17 @@ long bqpSolver_multiStartTabooSearch(
     const int *initSolution,
     const bqpSolver_Callback *callback
 ) {
-
     long long startTime = realtime_clock();
     int i;
     long iter;
-    vector<vector<long> > C(bqp->nVars);
+    vector<vector<double> > C(bqp->nVars);
     vector<int> u_I(bqp->nVars);
     int *I = vector_data<int>(u_I);
     vector<int> u_sol(bqp->nVars);
     int *solution = vector_data<int>(u_sol);
     vector<int> u_bestSol(bqp->nVars);
     int *bestSolution = vector_data<int>(u_bestSol);
-    int bestSolutionQuality;
+    double bestSolutionQuality;
     int n;
     int Z1Coeff = (bqp->nVars <= 500)? 10000 : 25000;
     int Z2Coeff = (bqp->nVars <= 500)? 2500 : 10000;
@@ -437,10 +437,11 @@ long bqpSolver_multiStartTabooSearch(
     return bqp->solutionQuality;
 }
 
+// not currently used
 int bqpSolver_naiveSearch(BQP *bqp) {
     int i;
     unsigned long long num, grayNum;
-    long cost, prevCost, minCost;
+    double cost, prevCost, minCost;
     int flippedBit;
     vector<int> u_sol(bqp->nVars);
     int *solution = vector_data<int>(u_sol);
@@ -488,10 +489,11 @@ int bqpSolver_naiveSearch(BQP *bqp) {
     return bqp->solutionQuality;
 }
 
-long bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, long startingObjective, long *changeInObjective) {
+// not currently used
+double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, double startingObjective, double *changeInObjective) {
     int i, j;
     long long iter = 0;
-    long objective, change;
+    double objective, change;
     int improved;
     for(i = 0; i < bqp->nVars; i++) {
         bqp->solution[i] = starting[i];
@@ -522,10 +524,11 @@ long bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restr
     return bqp->solutionQuality;
 }
 
-long bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted) {
+// not currently used
+double bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted) {
     int i;
-    vector<long> u_change(bqp->nVars);
-    long *changeInObjective = vector_data<long>(u_change);
+    vector<double> u_change(bqp->nVars);
+    double *changeInObjective = vector_data<double>(u_change);
     for(i = 0; i < bqp->nVars; i++) {
         changeInObjective[i] = bqpUtil_getChangeInObjective(bqp, starting, i);
     }

--- a/tabu/src/bqpSolver.h
+++ b/tabu/src/bqpSolver.h
@@ -26,9 +26,6 @@
 #define LAMBDA 5000
 #define ALPHA 0.4
 
-#define LARGE_NUMBER 999999999
-
-
 typedef struct bqpSolver_Callback {
   void (*func)(const struct bqpSolver_Callback *callback, BQP *bqp);
   void *context;
@@ -42,7 +39,7 @@ typedef struct bqpSolver_Callback {
  * \param timLimitInMilliSecs: time limit in milli seconds
  * \return best solution found
  */
-long bqpSolver_tabooSearch(BQP *bqp, int *starting, long startingObjective, int tt, long long ZCoeff, long long timeLimitInMilliSecs, const bqpSolver_Callback *callback);
+double bqpSolver_tabooSearch(BQP *bqp, int *starting, double startingObjective, int tt, long long ZCoeff, long long timeLimitInMilliSecs, const bqpSolver_Callback *callback);
 
 /**
  * Solves a BQP using basic local searching
@@ -52,7 +49,7 @@ long bqpSolver_tabooSearch(BQP *bqp, int *starting, long startingObjective, int 
  * \param changeInObjective: Partial derivative values for the starting solution
  * \return best solution found
  */
-long bqpSolver_localSearchInternal(BQP *bqp, int *starting, long startingObjective, long *changeInObjective);
+double bqpSolver_localSearchInternal(BQP *bqp, int *starting, double startingObjective, double *changeInObjective);
 
 /**
  * Solves a BQP using basic local searching (wrapper for localSearchInternal)
@@ -61,7 +58,7 @@ long bqpSolver_localSearchInternal(BQP *bqp, int *starting, long startingObjecti
  * \param starting: A starting solution
  * \return best solution found
  */
-long bqpSolver_localSearch(BQP *bqp, int *starting);
+double bqpSolver_localSearch(BQP *bqp, int *starting);
 
 /**
  * Helper function to bqpSolver_multiStartTabooSearch() function
@@ -72,7 +69,7 @@ long bqpSolver_localSearch(BQP *bqp, int *starting);
  * \param I: storage for selected variables
  * \return 
  */
-void bqpSolver_selectVariables(BQP *bqp, int n, long **C, int *I);
+void bqpSolver_selectVariables(BQP *bqp, int n, double **C, int *I);
 
 /**
  * Helper function to bqpSolver_multiStartTabooSearch() function
@@ -84,7 +81,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, long **C, int *I);
  * \param n: number of variables required to be selected
  * \return 
  */
-void bqpSolver_steepestAscent(int *solution, BQP *bqp, long **C, int *I, int n);
+void bqpSolver_steepestAscent(int *solution, BQP *bqp, double **C, int *I, int n);
 
 /**
  * Compute the C matrix (refer to the tabu search heuristic in the paper by Palubeckis
@@ -93,7 +90,7 @@ void bqpSolver_steepestAscent(int *solution, BQP *bqp, long **C, int *I, int n);
  * \param solution: current solution
  * \return void
  */
-void bqpSolver_computeC(long **C, BQP *bqp, int *solution);
+void bqpSolver_computeC(double **C, BQP *bqp, int *solution);
 
 /**
  * Simple tabu search solver with multi starts
@@ -102,7 +99,7 @@ void bqpSolver_computeC(long **C, BQP *bqp, int *solution);
  * \param numStarts: number of re starts
  * \return best solution found
  */
-long bqpSolver_multiStartTabooSearch(BQP *bqp, long long timeLimitInMilliSecs, int numStarts, int tabuTenure, const int *initSolution, const bqpSolver_Callback *callback);
+double bqpSolver_multiStartTabooSearch(BQP *bqp, long long timeLimitInMilliSecs, int numStarts, int tabuTenure, const int *initSolution, const bqpSolver_Callback *callback);
 
 /**
  * Exhaustive solver (takes too long for problems with more than 20 variables)
@@ -121,7 +118,7 @@ int bqpSolver_naiveSearch(BQP *bqp);
  * \param changeInObjective: Partial derivative values for the starting solution
  * \return best solution found
  */
-long bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, long startingObjective, long *changeInObjective);
+double bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restricted, double startingObjective, double *changeInObjective);
 
 /**
  * Another version to bqpSolver_localSearch() function
@@ -131,7 +128,7 @@ long bqpSolver_restrictedLocalSearchInternal(BQP *bqp, int *starting, int *restr
  * \param restricted: Tells if a variable is restricted or not
  * \return best solution found
  */
-long bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted);
+double bqpSolver_restrictedLocalSearch(BQP *bqp, int *starting, int *restricted);
 
 
 

--- a/tabu/src/bqpSolver.h
+++ b/tabu/src/bqpSolver.h
@@ -35,7 +35,7 @@ typedef struct bqpSolver_Callback {
  * Solves a BQP using simple tabu search heuristic
  * \param bqp: BQP problem to be solved
  * \param starting: A starting solution
- * \param ZCoeff: A parameter that defines the number of iterations
+ * \param ZCoeff: Parameter used to define the max number of iterations
  * \param timLimitInMilliSecs: time limit in milli seconds
  * \return best solution found
  */
@@ -74,7 +74,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, double **C, int *I);
 /**
  * Helper function to bqpSolver_multiStartTabooSearch() function
  * Uses steepest ascent to construct a new solution
- * \param solution: Old solution
+ * \param solution: solution to be updated
  * \param bqp: BQP problem to be solved
  * \param C: C matrix (refer paper for multi start tabu search by Palubeckis)
  * \param I: selected variables
@@ -84,7 +84,7 @@ void bqpSolver_selectVariables(BQP *bqp, int n, double **C, int *I);
 void bqpSolver_steepestAscent(int *solution, BQP *bqp, double **C, int *I, int n);
 
 /**
- * Compute the C matrix (refer to the tabu search heuristic in the paper by Palubeckis
+ * Compute the C matrix (refer to the tabu search heuristic in the paper by Palubeckis (p.262))
  * \param C: the matrix computed
  * \param bqp: the BQP
  * \param solution: current solution

--- a/tabu/src/bqpUtil.cpp
+++ b/tabu/src/bqpUtil.cpp
@@ -20,9 +20,9 @@
 using std::vector;
 
 
-long bqpUtil_getMaxBQPCoeff(BQP *bqp) {
+double bqpUtil_getMaxBQPCoeff(BQP *bqp) {
     int i, j;
-    long M = bqp->Q[0][0];
+    double M = bqp->Q[0][0];
     for(i = 0; i < bqp->nVars; i++) {
         for(j = 0; j < bqp->nVars; j++) {
             if(M < abs(bqp->Q[i][j])) {
@@ -50,18 +50,19 @@ void bqpUtil_print(BQP *bqp) {
     for(i = 0; i < bqp->nVars; i++) {
         printf("{");
         for(j = 0; j < bqp->nVars; j++) {
-            printf("%6ld,", bqp->Q[i][j]);
+            printf("%6f,", bqp->Q[i][j]);
         }
         printf("},\n");
     }
     printf("}\n");
 }
 
-long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) {
-    int i;
-    long change = 0, inc;
-    change += (oldSolution[flippedBit] == 1)? (-1 * bqp->Q[flippedBit][flippedBit]) : bqp->Q[flippedBit][flippedBit];
-    for(i = bqp->nVars; i--;) {
+double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) {
+    double change = 0, inc;
+    change += (oldSolution[flippedBit] == 1)? (-1 * bqp->Q[flippedBit][flippedBit]) : bqp->Q[flippedBit][flippedBit];  
+
+    // looking at every position except the flippedBit
+    for (int i = bqp->nVars; i--;) {
         if(!(oldSolution[i] ^ 1) && i ^ flippedBit) {
             inc = bqp->Q[flippedBit][i] + bqp->Q[i][flippedBit];
             change += (oldSolution[flippedBit] ^ 1) ?  inc : -inc;
@@ -70,9 +71,9 @@ long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit) {
     return change;
 }
 
-long bqpUtil_getObjective(BQP *bqp, int * solution) {
+double bqpUtil_getObjective(BQP *bqp, int * solution) {
     int i;
-    long cost = 0;
+    double cost = 0;
     vector<int> u_zeroSol(bqp->nVars);
     int *zeroSolution = vector_data<int>(u_zeroSol);
     for(i = bqp->nVars; i--;) {
@@ -87,9 +88,9 @@ long bqpUtil_getObjective(BQP *bqp, int * solution) {
     return cost;
 }
 
-long bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, long oldCost) {
+double bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, double oldCost) {
     int i;
-    long cost = oldCost;
+    double cost = oldCost;
     vector<int> u_old(bqp->nVars);
     int *oldSolCopy = vector_data<int>(u_old);
     for(i = 0; i < bqp->nVars; i++) {
@@ -121,7 +122,7 @@ void bqpUtil_initBQPSolution(BQP *bqp, const int *initSolution) {
 void bqpUtil_randomizeBQPSolution(BQP *bqp) {
     int i;
     for(i = 0; i < bqp->nVars; i++) {
-        if((rand() / (float)RAND_MAX) < 0.5) {
+        if((rand() / (double)RAND_MAX) < 0.5) {
             bqp->solution[i] = 0;
         }
         else {
@@ -134,7 +135,7 @@ void bqpUtil_randomizeBQPSolution(BQP *bqp) {
 
 void bqpUtil_printSolution(BQP *bqp) {
     int i;
-    printf("Objective function value: %ld\n", bqpUtil_getObjective(bqp, vector_data<int>(bqp->solution)));
+    printf("Objective function value: %f\n", bqpUtil_getObjective(bqp, vector_data<int>(bqp->solution)));
     printf("Variable assignment:\n");
     for(i = 0; i < bqp->nVars; i++) {
         printf("%d ", bqp->solution[i]);

--- a/tabu/src/bqpUtil.h
+++ b/tabu/src/bqpUtil.h
@@ -24,36 +24,36 @@
 #include <vector>
 
 /**
- * structure to represent a BQP
+ * Structure to represent a BQP
  * Q: the Q matrix
  * nVars: number of variables
- * solution: array fo size nVars where every entry is 0 or 1. current solution.
+ * solution: array of size nVars where every entry is 0 or 1. current solution.
  * solutionQuality: objective function value at solution
  * nIterations: number of iterations required to arrive at this solution
  */
 typedef struct {
-	std::vector<std::vector<long> >Q;
+	std::vector<std::vector<double> > Q;
 	int nVars;
 	std::vector<int> solution;
-	long solutionQuality;
+	double solutionQuality;
 	unsigned long long nIterations;
 	/*added to record more statistics.*/
 	unsigned long long restartNum;
 	unsigned long long iterNum;
 	unsigned long long evalNum;
-	long upperBound;
+	double upperBound;
 } BQP;
 
 
 /**
- * gets the maximum abs(Q[i][j]) in a bqp
+ * Gets the maximum abs(Q[i][j]) in a bqp
  * @param bqp
  * @return maximum Q[i][j]
  */
-long bqpUtil_getMaxBQPCoeff(BQP *bqp);
+double bqpUtil_getMaxBQPCoeff(BQP *bqp);
 
 /**
- * converts a generic bqp Q matrix into upper trianglular using:
+ * Converts a generic bqp Q matrix into upper triangular using:
  * Q[i][j] = Q[i][j] + Q[j][i] for all i < j
  * @param bqp
  * @return void
@@ -68,14 +68,14 @@ void bqpUtil_convertBQPToUpperTriangular(BQP *bqp);
 void bqpUtil_print(BQP *bqp);
 
 /**
- * Compute the value by which the ovjective function is changed if
+ * Compute the value by which the objective function is changed if
  * exactly one bit in the solution is flipped
  * @param bqp: the BQP
  * @param oldSolution: current solution
  * @param flippedBit: the bit that is flipped
  * @return change in objective
  */
-long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
+double bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
 
 /**
  * Computes the value of objective function of a BQP for a given solution
@@ -83,21 +83,21 @@ long bqpUtil_getChangeInObjective(BQP *bqp, int *oldSolution, int flippedBit);
  * @param solution: given solution
  * @return value of objective function
  */
-long bqpUtil_getObjective(BQP *bqp, int * solution);
+double bqpUtil_getObjective(BQP *bqp, int * solution);
 
 /**
  * Computes the value of objective function of a BQP for a given solution,
  * given some old solution.
- * If an old solution and the objective function value for that old soltuion
+ * If an old solution and the objective function value for that old solution
  * is known, then we can calculate the objective for the new solution quicker
- * by building up on the old soltuion.
+ * by building up on the old solution.
  * @param bqp: the BQP
  * @param solution: new solution
  * @param oldSolution: old solution
  * @param oldCost: value of objective function at old solution
  * @return value ot objective function at new solution
  */
-long bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, long oldCost);
+double bqpUtil_getObjectiveIncremental(BQP *bqp, int *solution, int *oldSolution, double oldCost);
 
 /**
  * Initialize the current solution in a BQP to all zeros
@@ -127,14 +127,14 @@ void bqpUtil_free(BQP *bqp);
  */
 void bqpUtil_printSolution(BQP *bqp);
 
-// replacement for vector.data() in ancient compilers not supporting it (VS2008, aka VS9)
+// Replacement for vector.data() in ancient compilers not supporting it (VS2008, aka VS9)
 // NB: we need to support VS9 is we want to build for python2.7 on windows
 template<typename T>
 T* vector_data(std::vector<T>& v) {
     return v.size() ? &v[0] : NULL;
 }
 
-// high-precision per-thread monotonic clock value expressed in milliseconds
+// High-precision per-thread monotonic clock value expressed in milliseconds
 long long realtime_clock();
 
 #endif

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -40,7 +40,7 @@ TabuSearch::TabuSearch(vector<vector<double> > Q, vector<int> initSol, int tenur
     bqp.nVars = nvars;
     bqp.restartNum = 0;
     bqp.Q.resize(nvars);
-    bqp.upperBound = std::numeric_limits<double>::lowest();
+    bqp.upperBound = -std::numeric_limits<double>::max();
     for (int i = 0; i < nvars; i++)
         bqp.Q[i].resize(nvars);
 

--- a/tabu/src/tabu_search.cc
+++ b/tabu/src/tabu_search.cc
@@ -20,16 +20,13 @@
 using std::vector;
 using std::size_t;
 
-TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int tenure, int scaleFactor, long int timeout):
-    sf(scaleFactor)
+TabuSearch::TabuSearch(vector<vector<double> > Q, vector<int> initSol, int tenure, long int timeout)
 {
     size_t nvars = Q.size();
     for (int i = 0; i < nvars; i++){
         if (Q[i].size() != nvars)
             throw Exception("Q must be a symmetric square matrix");
     }
-    if (scaleFactor < 0)
-        throw Exception("scaleFactor must be a positive integer");
 
     if (initSol.size() != nvars)
         throw Exception("length of init_solution doesn't match the size of Q");
@@ -43,7 +40,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
     bqp.nVars = nvars;
     bqp.restartNum = 0;
     bqp.Q.resize(nvars);
-    bqp.upperBound = std::numeric_limits<long>::min();
+    bqp.upperBound = std::numeric_limits<double>::lowest();
     for (int i = 0; i < nvars; i++)
         bqp.Q[i].resize(nvars);
 
@@ -51,7 +48,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
         for (int j = i; j < nvars; j++){
             if (Q[i][j] != Q[j][i])
                 throw Exception("Q must be symmetric");
-            bqp.Q[i][j] = bqp.Q[j][i] = (long) (Q[i][j] * scaleFactor);
+            bqp.Q[i][j] = bqp.Q[j][i] = Q[i][j];
         }
     }
     bqp.solution.resize(nvars);
@@ -62,7 +59,7 @@ TabuSearch::TabuSearch(vector<vector< double > > Q, vector<int> initSol, int ten
 
 double TabuSearch::bestEnergy()
 {
-    return (double)bqpUtil_getObjective(&bqp, vector_data<int>(bqp.solution)) / sf;
+    return bqpUtil_getObjective(&bqp, vector_data<int>(bqp.solution));
 }
 
 vector<int> TabuSearch::bestSolution()

--- a/tabu/src/tabu_search.h
+++ b/tabu/src/tabu_search.h
@@ -22,13 +22,12 @@
 class TabuSearch
 {
     public:
-        TabuSearch(std::vector<std::vector<double> > Q, std::vector<int> initSol, int tenure, int scaleFactor, long int timeout);
+        TabuSearch(std::vector<std::vector<double> > Q, std::vector<int> initSol, int tenure, long int timeout);
         double bestEnergy();
         std::vector<int> bestSolution();
 
     private:
         BQP bqp;
-        int sf;
 };
 
 #endif

--- a/tabu/tabu_search.i
+++ b/tabu/tabu_search.i
@@ -32,15 +32,13 @@ namespace std {
 %define TABU_DOCSTRING
 "Tabu Search
 
-handler = TabuSearch(q, init_solution, tenure, scaleFactor, timeout)
+handler = TabuSearch(q, init_solution, tenure, timeout)
 
     Args:
         q: QUBO as a list of list, or numpy matrix of double (float64) values.
            q must be symmetric.
         init_solution: List of 0/1 values, which defines the initial state of each variable.
         tenure: Tabu tenure. min(20, num_vars / 4) seems to be a good choice.
-        scaleFactor: Scaling factor for elements of q. The elements of q are stored as long ints using
-                     internal_q = long int (q * scaleFactor).
         timeout: Total running time in milliseconds.
 
 energy = handler.bestEnergy()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -109,3 +109,19 @@ class TestTabuSearch(unittest.TestCase, RunTimeAssertionMixin):
             # ~ 1000 ms (but be gracious on slow CI VMs)
             with self.assertRuntimeWithin(900, 1900):
                 wait([executor.submit(search, timeout=500) for _ in range(4)])
+
+    def test_float(self):
+        n = 20
+        init = [1] * n
+        tenure = len(init) - 1
+        timeout = 20
+
+        bqm = dimod.generators.random.uniform(n, 'BINARY', low=-100, high=100, seed=123)
+        Q, _ = tabu.TabuSampler._bqm_to_tabu_qubo(bqm)
+        search = tabu.TabuSearch(Q, init, tenure, timeout)
+        self.assertAlmostEqual(search.bestEnergy(), -1465.9867898)
+
+        bqm = dimod.generators.random.uniform(n, 'BINARY', low=-1, high=1, seed=123)
+        Q, _ = tabu.TabuSampler._bqm_to_tabu_qubo(bqm)
+        search = tabu.TabuSearch(Q, init, tenure, timeout)
+        self.assertAlmostEqual(search.bestEnergy(), -14.65986790)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -71,10 +71,9 @@ class TestTabuSearch(unittest.TestCase, RunTimeAssertionMixin):
         qubo = [[1]]
         init = [1]
         tenure = len(init) - 1
-        scale = 1
         timeout = 1
 
-        search = tabu.TabuSearch(qubo, init, tenure, scale, timeout)
+        search = tabu.TabuSearch(qubo, init, tenure, timeout)
 
         solution = list(search.bestSolution())
         energy = search.bestEnergy()
@@ -86,10 +85,9 @@ class TestTabuSearch(unittest.TestCase, RunTimeAssertionMixin):
         qubo = [[2, 1, 1], [1, 2, 1], [1, 1, 2]]
         init = [1, 1, 1]
         tenure = len(init) - 1
-        scale = 1
         timeout = 20
 
-        search = tabu.TabuSearch(qubo, init, tenure, scale, timeout)
+        search = tabu.TabuSearch(qubo, init, tenure, timeout)
 
         solution = list(search.bestSolution())
         energy = search.bestEnergy()
@@ -100,7 +98,7 @@ class TestTabuSearch(unittest.TestCase, RunTimeAssertionMixin):
     def test_concurrency(self):
 
         def search(timeout):
-            return tabu.TabuSearch([[1]], [1], 0, 1, timeout).bestEnergy()
+            return tabu.TabuSearch([[1]], [1], 0, timeout).bestEnergy()
 
         with ThreadPoolExecutor(max_workers=3) as executor:
 


### PR DESCRIPTION
Closes #29 

- int to float bias storage
- remove scale_factor from .sample()