### PR TITLE
debug appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,9 +47,13 @@ install:
   # about it being out of date.
   - "%PYTHON%\\python.exe -m pip install --upgrade pip setuptools"
 
+  - "%PYTHON%\\python.exe -m pip install wheel twine"
+
+  - "set PIP_PREFER_BINARY=yes"
+  - "%PYTHON%\\python.exe -m pip install dwave-tabu"
+
   # Install dependencies
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt -r tests\\requirements.txt"
-  - "%PYTHON%\\python.exe -m pip install wheel twine"
 
 build_script:
   # Build the compiled extension


### PR DESCRIPTION
Debugging weird appveyor failure between [here](https://ci.appveyor.com/project/dwave-adtt/dwave-tabu/builds/39093554) and [there](https://ci.appveyor.com/project/dwave-adtt/dwave-tabu/builds/39094104), with a [one-line diff](https://github.com/dwavesystems/dwave-tabu/compare/a347c185455675e5fc00c8426eae799f7cd308d4...4fcbd06a042d225953199df0c3ade01340ff7cac).