### PR TITLE
Use dev release of orb-ocean to verify a fix for orb-ocean#4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: dwave-tabu
 
 orbs:
-  ocean: dwave/ocean@1.2
+  ocean: dwave/ocean@dev:f8d3a15
 
 environment:
   PIP_PROGRESS_BAR: off


### PR DESCRIPTION
If the fix is correct, all tests that run on dimod 0.9 will fail. Tests that should have been failing to begin with -- `dimod~=0.9.0` is incompatible with the latest dwave-system installed by the latest dwave-hybrid, installed as a test requirement. See #75, https://github.com/dwavesystems/orb-ocean/issues/4.